### PR TITLE
Add admin evaluation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # application-platform
 
+## Admin-Bewertungsprozess
+
+Der Ablauf unter `/admin/evaluation` ersetzt die Schritte 3 bis 5 des früheren
+Bewertungsprozess-Repositories:
+
+1. Phase auswählen und Bewerter-CSV mit `name,email,new,max` hochladen.
+2. Matching prüfen und verbindlich speichern.
+3. Testmail senden und anschließend den produktiven Versand bestätigen.
+4. Bestandene E-Mail-Adressen einfügen oder Entscheidungen einzeln setzen.
+5. Phase abschließen.
+
+Die feste E-Mail-Vorlage liegt in
+`frontend/src/emails/reviewerAssignmentEmail.ts`. Die jährlich anzupassenden
+Fristen und Links stehen gebündelt in
+`frontend/src/config/reviewEmailConfig.ts`. Für eine dauerhafte Anpassung muss
+nur diese Konfigurationsdatei geändert und die Anwendung neu deployed werden.
+Die Werte können vor einem einzelnen Versand zusätzlich auf der Admin-Seite
+überschrieben werden.
+
 ## Local Testing
 
 ### 1. Prerequisites
@@ -354,4 +373,3 @@ https://docs.github.com/en/packages/working-with-a-github-packages-registry/work
     - HTTP/2 Support: On
     - HSTS Enabled: On
     - Agree to Terms of Service
-

--- a/frontend/scripts/reviewer-email.test.ts
+++ b/frontend/scripts/reviewer-email.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createReviewerAssignmentEmail } from "../src/emails/reviewerAssignmentEmail";
+
+test("renders reviewer assignments and escapes team names", () => {
+  const html = createReviewerAssignmentEmail({
+    phaseLabel: "Phase 1",
+    confirmationDeadline: "01.01.2027",
+    confirmationUrl: "https://example.org/confirm",
+    ratingDeadline: "02.01.2027",
+    instructionsUrl: "https://example.org/instructions",
+    ratingUrl: "https://example.org/rating",
+    reviewUrl: "https://example.org/review",
+    phaseNote: "Bitte Interessenkonflikte melden.",
+    applications: [{ teamName: "Team <script>" }],
+  });
+
+  assert.match(html, /Team &lt;script&gt;/);
+  assert.doesNotMatch(html, /Team <script>/);
+  assert.match(html, /https:\/\/example\.org\/review/);
+});
+
+test("rejects non-http links", () => {
+  assert.throws(() =>
+    createReviewerAssignmentEmail({
+      phaseLabel: "Phase 1",
+      confirmationDeadline: "01.01.2027",
+      confirmationUrl: "javascript:alert(1)",
+      ratingDeadline: "02.01.2027",
+      instructionsUrl: "https://example.org/instructions",
+      ratingUrl: "https://example.org/rating",
+      reviewUrl: "https://example.org/review",
+      phaseNote: "Hinweis",
+      applications: [{ teamName: "Team" }],
+    }),
+  );
+});

--- a/frontend/scripts/reviewer-matching.test.ts
+++ b/frontend/scripts/reviewer-matching.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assignReviewers,
+  MatchingApplication,
+  MatchingReviewer,
+} from "../src/utils/reviewerMatching";
+
+const applications: MatchingApplication[] = [
+  {
+    applicationId: "application-2",
+    applicantUserId: "applicant-2",
+    teamName: "Team 2",
+    email: "team2@example.org",
+  },
+  {
+    applicationId: "application-1",
+    applicantUserId: "applicant-1",
+    teamName: "Team 1",
+    email: "team1@example.org",
+  },
+];
+
+const reviewers: MatchingReviewer[] = [
+  {
+    userId: "reviewer-new",
+    name: "New Reviewer",
+    email: "new@example.org",
+    isExperienced: false,
+    maxApplications: 2,
+  },
+  {
+    userId: "reviewer-experienced-2",
+    name: "Experienced Reviewer 2",
+    email: "experienced2@example.org",
+    isExperienced: true,
+    maxApplications: 1,
+  },
+  {
+    userId: "reviewer-experienced-1",
+    name: "Experienced Reviewer 1",
+    email: "experienced1@example.org",
+    isExperienced: true,
+    maxApplications: 1,
+  },
+];
+
+test("assigns the requested number and one experienced reviewer per application", () => {
+  const assignments = assignReviewers(applications, reviewers, 2);
+
+  assert.equal(assignments.length, 4);
+  for (const application of applications) {
+    const applicationAssignments = assignments.filter(
+      (assignment) => assignment.applicationId === application.applicationId,
+    );
+    assert.equal(applicationAssignments.length, 2);
+    assert.equal(
+      applicationAssignments.some(
+        (assignment) => assignment.reviewerIsExperienced,
+      ),
+      true,
+    );
+  }
+});
+
+test("is deterministic regardless of application input order", () => {
+  assert.deepEqual(
+    assignReviewers(applications, reviewers, 2),
+    assignReviewers([...applications].reverse(), reviewers, 2),
+  );
+});
+
+test("rejects insufficient experienced capacity", () => {
+  assert.throws(
+    () =>
+      assignReviewers(
+        applications,
+        reviewers.map((reviewer) => ({ ...reviewer, isExperienced: false })),
+        2,
+      ),
+    /erfahrene Bewerter/,
+  );
+});

--- a/frontend/src/actions/answers/downloadUpload.ts
+++ b/frontend/src/actions/answers/downloadUpload.ts
@@ -1,0 +1,126 @@
+"use server";
+
+import { z } from "zod";
+
+import {
+  getSupabaseCookiesUtilClient,
+  getSupabaseServiceRoleClient,
+} from "@/supabase-utils/cookiesUtilClient";
+import { UserRole } from "@/utils/userRole";
+
+const uploadTypeSchema = z.enum(["image", "pdf", "video"]);
+
+export async function getApplicationUploadUrl(
+  applicationId: string,
+  questionId: string,
+  uploadTypeInput: "image" | "pdf" | "video",
+) {
+  z.string().uuid().parse(applicationId);
+  z.string().uuid().parse(questionId);
+  const uploadType = uploadTypeSchema.parse(uploadTypeInput);
+
+  const supabase = await getSupabaseCookiesUtilClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) throw new Error("Nicht angemeldet.");
+
+  const { data: profile, error: profileError } = await supabase
+    .from("user_profiles_table")
+    .select("userrole,isactive")
+    .eq("userid", user.id)
+    .single();
+  if (profileError || !profile?.isactive) {
+    throw new Error("Kein Zugriff auf diese Datei.");
+  }
+
+  const supabaseAdmin = getSupabaseServiceRoleClient();
+  const { data: answer, error: answerError } = await supabaseAdmin
+    .from("answer_table")
+    .select("answerid,applicationid,questionid")
+    .eq("applicationid", applicationId)
+    .eq("questionid", questionId)
+    .single();
+  if (answerError) throw answerError;
+
+  const { data: application, error: applicationError } = await supabaseAdmin
+    .from("application_table")
+    .select("userid")
+    .eq("applicationid", applicationId)
+    .single();
+  if (applicationError) throw applicationError;
+
+  let isAllowed =
+    profile.userrole === UserRole.Admin || application.userid === user.id;
+  if (profile.userrole === UserRole.Reviewer) {
+    const { data: question, error: questionError } = await supabaseAdmin
+      .from("question_table")
+      .select("phaseid")
+      .eq("questionid", questionId)
+      .single();
+    if (questionError) throw questionError;
+    const { data: answerPhase, error: answerPhaseError } = await supabaseAdmin
+      .from("phase_table")
+      .select("phaseorder")
+      .eq("phaseid", question.phaseid)
+      .single();
+    if (answerPhaseError) throw answerPhaseError;
+    const { data: assignments, error: assignmentError } = await supabaseAdmin
+      .from("phase_assignment_table")
+      .select("phase_id")
+      .eq("user_role_1_id", application.userid)
+      .eq("user_role_2_id", user.id);
+    if (assignmentError) throw assignmentError;
+    const assignmentPhaseIds = assignments?.map((item) => item.phase_id) ?? [];
+    if (assignmentPhaseIds.length > 0) {
+      const { data: assignmentPhases, error: assignmentPhaseError } =
+        await supabaseAdmin
+          .from("phase_table")
+          .select("phaseorder")
+          .in("phaseid", assignmentPhaseIds);
+      if (assignmentPhaseError) throw assignmentPhaseError;
+      isAllowed =
+        assignmentPhases?.some(
+          (phase) => phase.phaseorder >= answerPhase.phaseorder,
+        ) ?? false;
+    }
+  }
+
+  if (!isAllowed) throw new Error("Kein Zugriff auf diese Datei.");
+
+  let storedFileName: string | null = null;
+  if (uploadType === "image") {
+    const { data, error } = await supabaseAdmin
+      .from("image_upload_answer_table")
+      .select("imagename")
+      .eq("answerid", answer.answerid)
+      .single();
+    if (error) throw error;
+    storedFileName = data.imagename;
+  } else if (uploadType === "pdf") {
+    const { data, error } = await supabaseAdmin
+      .from("pdf_upload_answer_table")
+      .select("pdfname")
+      .eq("answerid", answer.answerid)
+      .single();
+    if (error) throw error;
+    storedFileName = data.pdfname;
+  } else {
+    const { data, error } = await supabaseAdmin
+      .from("video_upload_answer_table")
+      .select("videoname")
+      .eq("answerid", answer.answerid)
+      .single();
+    if (error) throw error;
+    storedFileName = data.videoname;
+  }
+
+  const bucket = `${uploadType}-${questionId}`;
+  const path = `${application.userid}_${storedFileName}`;
+  const { data: signedUrl, error: signedUrlError } = await supabaseAdmin.storage
+    .from(bucket)
+    .createSignedUrl(path, 60 * 10);
+  if (signedUrlError) throw signedUrlError;
+  return signedUrl.signedUrl;
+}

--- a/frontend/src/actions/evaluation.ts
+++ b/frontend/src/actions/evaluation.ts
@@ -1,0 +1,790 @@
+"use server";
+
+import { parse } from "csv-parse/sync";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { sendEmail } from "@/actions/smtp";
+import {
+  reviewEmailDefaults,
+  ReviewEmailDefaults,
+} from "@/config/reviewEmailConfig";
+import { createReviewerAssignmentEmail } from "@/emails/reviewerAssignmentEmail";
+import { createLogger } from "@/logger/logger";
+import { PhaseData } from "@/store/slices/phaseSlice";
+import {
+  getSupabaseCookiesUtilClient,
+  getSupabaseServiceRoleClient,
+} from "@/supabase-utils/cookiesUtilClient";
+import { getURL } from "@/utils/helpers";
+import {
+  assignReviewers,
+  MatchingApplication,
+  MatchingReviewer,
+  ReviewerAssignment,
+} from "@/utils/reviewerMatching";
+import { UserRole } from "@/utils/userRole";
+
+const log = createLogger("actions/evaluation");
+
+interface CsvReviewer {
+  name: string;
+  email: string;
+  new: string;
+  max: string;
+}
+
+export interface EvaluationAssignment {
+  assignmentId: string;
+  phaseId: string;
+  applicantUserId: string;
+  applicationId: string;
+  teamName: string;
+  applicantEmail: string;
+  reviewerUserId: string;
+  reviewerEmail: string;
+}
+
+export interface EvaluationDashboardData {
+  phases: PhaseData[];
+  applications: MatchingApplication[];
+  eligibleApplicantIdsByPhase: Record<string, string[]>;
+  assignments: EvaluationAssignment[];
+  outcomes: {
+    outcomeId: string;
+    phaseId: string;
+    applicantUserId: string;
+    outcome: boolean;
+  }[];
+  emailDefaults: ReviewEmailDefaults;
+}
+
+const assignmentSchema = z.object({
+  applicationId: z.string().uuid(),
+  applicantUserId: z.string().uuid(),
+  reviewerUserId: z.string().uuid(),
+});
+
+const emailSettingsSchema = z.object({
+  subject: z.string().trim().min(1),
+  confirmationDeadline: z.string().trim().min(1),
+  confirmationUrl: z.url(),
+  ratingDeadline: z.string().trim().min(1),
+  instructionsUrl: z.url(),
+  ratingUrl: z.url(),
+  phaseNote: z.string().trim().min(1),
+});
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase().replace("@googlemail.com", "@gmail.com");
+}
+
+async function requireAdmin() {
+  const supabase = await getSupabaseCookiesUtilClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    throw new Error("Nicht angemeldet.");
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("user_profiles_table")
+    .select("userrole,isactive")
+    .eq("userid", user.id)
+    .single();
+
+  if (
+    profileError ||
+    !profile?.isactive ||
+    profile.userrole !== UserRole.Admin
+  ) {
+    throw new Error("Diese Aktion ist nur für Administratoren erlaubt.");
+  }
+
+  return {
+    user,
+    supabaseAdmin: getSupabaseServiceRoleClient(),
+  };
+}
+
+async function listAllAuthUsers(
+  supabaseAdmin: ReturnType<typeof getSupabaseServiceRoleClient>,
+) {
+  const {
+    data: { users },
+    error,
+  } = await supabaseAdmin.auth.admin.listUsers({ page: 1, perPage: 1000 });
+  if (error) throw error;
+  return users;
+}
+
+async function fetchEligibleApplications(
+  supabaseAdmin: ReturnType<typeof getSupabaseServiceRoleClient>,
+  phaseId: string,
+): Promise<MatchingApplication[]> {
+  const { data: phase, error: phaseError } = await supabaseAdmin
+    .from("phase_table")
+    .select("phaseid,phaseorder")
+    .eq("phaseid", phaseId)
+    .single();
+  if (phaseError) throw phaseError;
+
+  const [
+    { data: applications, error: applicationError },
+    { data: profiles, error: profileError },
+    authUsers,
+  ] = await Promise.all([
+    supabaseAdmin
+      .from("application_table")
+      .select("applicationid,userid,team_name"),
+    supabaseAdmin
+      .from("user_profiles_table")
+      .select("userid,userrole,isactive"),
+    listAllAuthUsers(supabaseAdmin),
+  ]);
+  if (applicationError) throw applicationError;
+  if (profileError) throw profileError;
+
+  const activeApplicantIds = new Set(
+    profiles
+      ?.filter(
+        (profile) =>
+          profile.userrole === UserRole.Applicant && profile.isactive,
+      )
+      .map((profile) => profile.userid),
+  );
+
+  let eligibleApplicantIds = activeApplicantIds;
+  if (phase.phaseorder > 0) {
+    const { data: previousPhase, error: previousPhaseError } =
+      await supabaseAdmin
+        .from("phase_table")
+        .select("phaseid")
+        .eq("phaseorder", phase.phaseorder - 1)
+        .single();
+    if (previousPhaseError) throw previousPhaseError;
+
+    const { data: outcomes, error: outcomeError } = await supabaseAdmin
+      .from("phase_outcome_table")
+      .select("user_id")
+      .eq("phase_id", previousPhase.phaseid)
+      .eq("outcome", true);
+    if (outcomeError) throw outcomeError;
+    eligibleApplicantIds = new Set(
+      outcomes
+        ?.map((outcome) => outcome.user_id)
+        .filter((userId) => activeApplicantIds.has(userId)),
+    );
+  }
+
+  const emailByUserId = new Map(
+    authUsers.map((authUser) => [authUser.id, authUser.email ?? ""]),
+  );
+
+  return (applications ?? [])
+    .filter((application) => eligibleApplicantIds.has(application.userid))
+    .map((application) => ({
+      applicationId: application.applicationid,
+      applicantUserId: application.userid,
+      teamName:
+        application.team_name?.trim() ||
+        emailByUserId.get(application.userid) ||
+        application.applicationid,
+      email: emailByUserId.get(application.userid) || "",
+    }));
+}
+
+export async function fetchEvaluationDashboardData(): Promise<EvaluationDashboardData> {
+  const { supabaseAdmin } = await requireAdmin();
+  const [
+    authUsers,
+    phasesResult,
+    applicationsResult,
+    assignmentsResult,
+    outcomesResult,
+    profilesResult,
+  ] = await Promise.all([
+    listAllAuthUsers(supabaseAdmin),
+    supabaseAdmin.from("phase_table").select("*").order("phaseorder"),
+    supabaseAdmin
+      .from("application_table")
+      .select("applicationid,userid,team_name"),
+    supabaseAdmin.from("phase_assignment_table").select("*"),
+    supabaseAdmin.from("phase_outcome_table").select("*"),
+    supabaseAdmin
+      .from("user_profiles_table")
+      .select("userid,userrole,isactive"),
+  ]);
+
+  for (const result of [
+    phasesResult,
+    applicationsResult,
+    assignmentsResult,
+    outcomesResult,
+    profilesResult,
+  ]) {
+    if (result.error) throw result.error;
+  }
+
+  const authUserById = new Map(authUsers.map((user) => [user.id, user]));
+  const applicationByApplicantId = new Map(
+    applicationsResult.data?.map((application) => [
+      application.userid,
+      application,
+    ]),
+  );
+
+  const activeApplicantIds = new Set(
+    profilesResult.data
+      ?.filter(
+        (profile) =>
+          profile.userrole === UserRole.Applicant && profile.isactive,
+      )
+      .map((profile) => profile.userid),
+  );
+
+  const applications = (applicationsResult.data ?? [])
+    .filter((application) => activeApplicantIds.has(application.userid))
+    .map((application) => ({
+      applicationId: application.applicationid,
+      applicantUserId: application.userid,
+      teamName:
+        application.team_name?.trim() ||
+        authUserById.get(application.userid)?.email ||
+        application.applicationid,
+      email: authUserById.get(application.userid)?.email || "",
+    }));
+
+  const eligibleApplicantIdsByPhase: Record<string, string[]> = {};
+  for (const phase of phasesResult.data ?? []) {
+    eligibleApplicantIdsByPhase[phase.phaseid] = (
+      await fetchEligibleApplications(supabaseAdmin, phase.phaseid)
+    ).map((application) => application.applicantUserId);
+  }
+
+  return {
+    phases: (phasesResult.data ?? []) as PhaseData[],
+    applications,
+    eligibleApplicantIdsByPhase,
+    assignments: (assignmentsResult.data ?? []).flatMap((assignment) => {
+      const application = applicationByApplicantId.get(
+        assignment.user_role_1_id,
+      );
+      if (!application) return [];
+      return [
+        {
+          assignmentId: assignment.assignment_id,
+          phaseId: assignment.phase_id,
+          applicantUserId: assignment.user_role_1_id,
+          applicationId: application.applicationid,
+          teamName:
+            application.team_name?.trim() ||
+            authUserById.get(assignment.user_role_1_id)?.email ||
+            application.applicationid,
+          applicantEmail:
+            authUserById.get(assignment.user_role_1_id)?.email || "",
+          reviewerUserId: assignment.user_role_2_id,
+          reviewerEmail:
+            authUserById.get(assignment.user_role_2_id)?.email || "",
+        },
+      ];
+    }),
+    outcomes: (outcomesResult.data ?? []).map((outcome) => ({
+      outcomeId: outcome.outcome_id,
+      phaseId: outcome.phase_id,
+      applicantUserId: outcome.user_id,
+      outcome: outcome.outcome,
+    })),
+    emailDefaults: reviewEmailDefaults,
+  };
+}
+
+export async function previewReviewerMatching(
+  phaseId: string,
+  csvText: string,
+  reviewersPerApplication: number,
+): Promise<ReviewerAssignment[]> {
+  const { supabaseAdmin } = await requireAdmin();
+  const rows = parse(csvText, {
+    bom: true,
+    columns: (headers: string[]) =>
+      headers.map((header) => header.trim().toLowerCase()),
+    skip_empty_lines: true,
+    trim: true,
+  }) as CsvReviewer[];
+
+  if (rows.length === 0) {
+    throw new Error("Die Bewerter-CSV ist leer.");
+  }
+
+  const authUsers = await listAllAuthUsers(supabaseAdmin);
+  const { data: profiles, error: profileError } = await supabaseAdmin
+    .from("user_profiles_table")
+    .select("userid,userrole,isactive");
+  if (profileError) throw profileError;
+
+  const reviewerProfileById = new Map(
+    profiles
+      ?.filter(
+        (profile) => profile.userrole === UserRole.Reviewer && profile.isactive,
+      )
+      .map((profile) => [profile.userid, profile]),
+  );
+  const authUserByEmail = new Map(
+    authUsers.map((authUser) => [
+      normalizeEmail(authUser.email ?? ""),
+      authUser,
+    ]),
+  );
+
+  const reviewers: MatchingReviewer[] = rows.map((row, index) => {
+    if (
+      !row.name ||
+      !row.email ||
+      row.new === undefined ||
+      row.max === undefined
+    ) {
+      throw new Error(
+        `Zeile ${index + 2}: Erwartet werden die Spalten name,email,new,max.`,
+      );
+    }
+    const authUser = authUserByEmail.get(normalizeEmail(row.email));
+    if (!authUser || !reviewerProfileById.has(authUser.id)) {
+      throw new Error(
+        `${row.email} besitzt keinen aktiven Reviewer-Account im Portal.`,
+      );
+    }
+
+    const normalizedNewValue = row.new.trim().toLowerCase();
+    if (!["ja", "nein", "yes", "no"].includes(normalizedNewValue)) {
+      throw new Error(
+        `Zeile ${index + 2}: "new" muss ja/nein oder yes/no sein.`,
+      );
+    }
+
+    return {
+      userId: authUser.id,
+      name: row.name.trim(),
+      email: authUser.email!,
+      isExperienced: ["nein", "no"].includes(normalizedNewValue),
+      maxApplications: Number(row.max),
+    };
+  });
+
+  const applications = await fetchEligibleApplications(supabaseAdmin, phaseId);
+  return assignReviewers(applications, reviewers, reviewersPerApplication);
+}
+
+export async function saveReviewerAssignments(
+  phaseId: string,
+  assignmentsInput: Pick<
+    ReviewerAssignment,
+    "applicationId" | "applicantUserId" | "reviewerUserId"
+  >[],
+) {
+  const { supabaseAdmin } = await requireAdmin();
+  const assignments = z.array(assignmentSchema).min(1).parse(assignmentsInput);
+  const eligibleApplications = await fetchEligibleApplications(
+    supabaseAdmin,
+    phaseId,
+  );
+  const eligibleApplicationById = new Map(
+    eligibleApplications.map((application) => [
+      application.applicationId,
+      application,
+    ]),
+  );
+
+  const { data: profiles, error: profileError } = await supabaseAdmin
+    .from("user_profiles_table")
+    .select("userid,userrole,isactive");
+  if (profileError) throw profileError;
+  const activeReviewerIds = new Set(
+    profiles
+      ?.filter(
+        (profile) => profile.userrole === UserRole.Reviewer && profile.isactive,
+      )
+      .map((profile) => profile.userid),
+  );
+
+  const seenPairs = new Set<string>();
+  for (const assignment of assignments) {
+    const application = eligibleApplicationById.get(assignment.applicationId);
+    if (
+      !application ||
+      application.applicantUserId !== assignment.applicantUserId
+    ) {
+      throw new Error("Das Matching enthält eine ungültige Bewerbung.");
+    }
+    if (!activeReviewerIds.has(assignment.reviewerUserId)) {
+      throw new Error("Das Matching enthält einen inaktiven Bewerter.");
+    }
+    const pair = `${assignment.applicantUserId}:${assignment.reviewerUserId}`;
+    if (seenPairs.has(pair)) {
+      throw new Error("Das Matching enthält eine doppelte Zuweisung.");
+    }
+    seenPairs.add(pair);
+  }
+
+  const { data: previousAssignments, error: previousAssignmentsError } =
+    await supabaseAdmin
+      .from("phase_assignment_table")
+      .select("phase_id,user_role_1_id,user_role_2_id")
+      .eq("phase_id", phaseId);
+  if (previousAssignmentsError) throw previousAssignmentsError;
+
+  const { error: deleteError } = await supabaseAdmin
+    .from("phase_assignment_table")
+    .delete()
+    .eq("phase_id", phaseId);
+  if (deleteError) throw deleteError;
+
+  const { error: insertError } = await supabaseAdmin
+    .from("phase_assignment_table")
+    .insert(
+      assignments.map((assignment) => ({
+        phase_id: phaseId,
+        user_role_1_id: assignment.applicantUserId,
+        user_role_2_id: assignment.reviewerUserId,
+      })),
+    );
+
+  if (insertError) {
+    log.error(
+      `Could not save reviewer assignments: ${JSON.stringify(insertError)}`,
+    );
+    if (previousAssignments && previousAssignments.length > 0) {
+      await supabaseAdmin
+        .from("phase_assignment_table")
+        .insert(previousAssignments);
+    }
+    throw insertError;
+  }
+
+  revalidatePath("/admin/evaluation");
+  revalidatePath("/review/applications");
+  return { savedAssignments: assignments.length };
+}
+
+async function buildReviewerEmails(
+  phaseId: string,
+  settingsInput: ReviewEmailDefaults,
+) {
+  const { user, supabaseAdmin } = await requireAdmin();
+  const settings = emailSettingsSchema.parse(settingsInput);
+  const [
+    { data: phase, error: phaseError },
+    { data: assignments, error: assignmentError },
+    authUsers,
+    { data: applications, error: applicationError },
+  ] = await Promise.all([
+    supabaseAdmin
+      .from("phase_table")
+      .select("phaseid,phaselabel")
+      .eq("phaseid", phaseId)
+      .single(),
+    supabaseAdmin
+      .from("phase_assignment_table")
+      .select("user_role_1_id,user_role_2_id")
+      .eq("phase_id", phaseId),
+    listAllAuthUsers(supabaseAdmin),
+    supabaseAdmin.from("application_table").select("userid,team_name"),
+  ]);
+  if (phaseError) throw phaseError;
+  if (assignmentError) throw assignmentError;
+  if (applicationError) throw applicationError;
+  if (!assignments || assignments.length === 0) {
+    throw new Error("Für diese Phase ist noch kein Matching gespeichert.");
+  }
+
+  const authUserById = new Map(
+    authUsers.map((authUser) => [authUser.id, authUser]),
+  );
+  const applicationByUserId = new Map(
+    applications?.map((application) => [application.userid, application]),
+  );
+  const applicantIdsByReviewer = new Map<string, Set<string>>();
+  for (const assignment of assignments) {
+    const applicantIds =
+      applicantIdsByReviewer.get(assignment.user_role_2_id) ??
+      new Set<string>();
+    applicantIds.add(assignment.user_role_1_id);
+    applicantIdsByReviewer.set(assignment.user_role_2_id, applicantIds);
+  }
+
+  const reviewUrl = `${getURL()}review/applications`;
+  const messages = [...applicantIdsByReviewer.entries()].map(
+    ([reviewerId, applicantIds]) => {
+      const reviewer = authUserById.get(reviewerId);
+      if (!reviewer?.email) {
+        throw new Error(
+          `Für Reviewer ${reviewerId} wurde keine E-Mail gefunden.`,
+        );
+      }
+      return {
+        reviewerEmail: reviewer.email,
+        subject: settings.subject,
+        html: createReviewerAssignmentEmail({
+          phaseLabel: phase.phaselabel,
+          confirmationDeadline: settings.confirmationDeadline,
+          confirmationUrl: settings.confirmationUrl,
+          ratingDeadline: settings.ratingDeadline,
+          instructionsUrl: settings.instructionsUrl,
+          ratingUrl: settings.ratingUrl,
+          reviewUrl,
+          phaseNote: settings.phaseNote,
+          applications: [...applicantIds].map((applicantId) => ({
+            teamName:
+              applicationByUserId.get(applicantId)?.team_name?.trim() ||
+              authUserById.get(applicantId)?.email ||
+              applicantId,
+          })),
+        }),
+      };
+    },
+  );
+
+  return { adminEmail: user.email!, messages };
+}
+
+export async function sendReviewerTestEmail(
+  phaseId: string,
+  settings: ReviewEmailDefaults,
+) {
+  const { adminEmail, messages } = await buildReviewerEmails(phaseId, settings);
+  const example = messages[0];
+  await sendEmail(
+    adminEmail,
+    `[TEST] ${example.subject}`,
+    `<p><strong>Testmail für ${example.reviewerEmail}</strong></p>${example.html}`,
+  );
+  return { recipient: adminEmail };
+}
+
+export async function sendReviewerAssignmentEmails(
+  phaseId: string,
+  settings: ReviewEmailDefaults,
+) {
+  const { messages } = await buildReviewerEmails(phaseId, settings);
+  const errors: string[] = [];
+
+  for (const message of messages) {
+    try {
+      await sendEmail(message.reviewerEmail, message.subject, message.html);
+    } catch {
+      errors.push(message.reviewerEmail);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Versand an ${errors.length} Empfänger fehlgeschlagen: ${errors.join(", ")}`,
+    );
+  }
+  return { sentEmails: messages.length };
+}
+
+export async function savePhaseDecision(
+  phaseId: string,
+  applicantUserId: string,
+  outcome: boolean,
+) {
+  const { user, supabaseAdmin } = await requireAdmin();
+  z.string().uuid().parse(phaseId);
+  z.string().uuid().parse(applicantUserId);
+
+  const eligibleApplications = await fetchEligibleApplications(
+    supabaseAdmin,
+    phaseId,
+  );
+  if (
+    !eligibleApplications.some(
+      (application) => application.applicantUserId === applicantUserId,
+    )
+  ) {
+    throw new Error(
+      "Dieses Startup ist für die ausgewählte Phase nicht teilnahmeberechtigt.",
+    );
+  }
+
+  const { data: existingOutcomes, error: selectError } = await supabaseAdmin
+    .from("phase_outcome_table")
+    .select("outcome_id")
+    .eq("phase_id", phaseId)
+    .eq("user_id", applicantUserId);
+  if (selectError) throw selectError;
+
+  if (existingOutcomes && existingOutcomes.length > 0) {
+    const { error } = await supabaseAdmin
+      .from("phase_outcome_table")
+      .update({
+        outcome,
+        reviewed_by: user.id,
+        review_date: new Date().toISOString(),
+      })
+      .eq("phase_id", phaseId)
+      .eq("user_id", applicantUserId);
+    if (error) throw error;
+  } else {
+    const { error } = await supabaseAdmin.from("phase_outcome_table").insert({
+      phase_id: phaseId,
+      user_id: applicantUserId,
+      outcome,
+      reviewed_by: user.id,
+      review_date: new Date().toISOString(),
+    });
+    if (error) throw error;
+  }
+
+  revalidatePath("/admin/evaluation");
+  return { outcome };
+}
+
+export async function saveBulkPhaseDecisions(
+  phaseId: string,
+  approvedEmailsText: string,
+) {
+  const { user, supabaseAdmin } = await requireAdmin();
+  z.string().uuid().parse(phaseId);
+  const approvedEmails = new Set(
+    approvedEmailsText
+      .split(/[\s,;]+/)
+      .map(normalizeEmail)
+      .filter(Boolean),
+  );
+  const eligibleApplications = await fetchEligibleApplications(
+    supabaseAdmin,
+    phaseId,
+  );
+  const eligibleApplicationByEmail = new Map(
+    eligibleApplications.map((application) => [
+      normalizeEmail(application.email),
+      application,
+    ]),
+  );
+  const unknownEmails = [...approvedEmails].filter(
+    (email) => !eligibleApplicationByEmail.has(email),
+  );
+  if (unknownEmails.length > 0) {
+    throw new Error(
+      `Diese E-Mail-Adressen sind in der Phase nicht teilnahmeberechtigt: ${unknownEmails.join(", ")}`,
+    );
+  }
+
+  const { data: existingOutcomes, error: existingOutcomeError } =
+    await supabaseAdmin
+      .from("phase_outcome_table")
+      .select("user_id")
+      .eq("phase_id", phaseId);
+  if (existingOutcomeError) throw existingOutcomeError;
+  const existingApplicantIds = new Set(
+    existingOutcomes?.map((outcome) => outcome.user_id),
+  );
+  const now = new Date().toISOString();
+  const passedApplicantIds = eligibleApplications
+    .filter((application) =>
+      approvedEmails.has(normalizeEmail(application.email)),
+    )
+    .map((application) => application.applicantUserId);
+  const failedApplicantIds = eligibleApplications
+    .filter(
+      (application) => !approvedEmails.has(normalizeEmail(application.email)),
+    )
+    .map((application) => application.applicantUserId);
+
+  for (const [applicantIds, outcome] of [
+    [passedApplicantIds, true],
+    [failedApplicantIds, false],
+  ] as const) {
+    const idsToUpdate = applicantIds.filter((id) =>
+      existingApplicantIds.has(id),
+    );
+    if (idsToUpdate.length > 0) {
+      const { error } = await supabaseAdmin
+        .from("phase_outcome_table")
+        .update({ outcome, reviewed_by: user.id, review_date: now })
+        .eq("phase_id", phaseId)
+        .in("user_id", idsToUpdate);
+      if (error) throw error;
+    }
+  }
+
+  const newOutcomes = eligibleApplications
+    .filter(
+      (application) => !existingApplicantIds.has(application.applicantUserId),
+    )
+    .map((application) => ({
+      phase_id: phaseId,
+      user_id: application.applicantUserId,
+      outcome: approvedEmails.has(normalizeEmail(application.email)),
+      reviewed_by: user.id,
+      review_date: now,
+    }));
+  if (newOutcomes.length > 0) {
+    const { error } = await supabaseAdmin
+      .from("phase_outcome_table")
+      .insert(newOutcomes);
+    if (error) throw error;
+  }
+
+  revalidatePath("/admin/evaluation");
+  return {
+    passed: passedApplicantIds.length,
+    failed: failedApplicantIds.length,
+  };
+}
+
+export async function finishPhaseEvaluation(phaseId: string) {
+  const { supabaseAdmin } = await requireAdmin();
+  z.string().uuid().parse(phaseId);
+  const eligibleApplications = await fetchEligibleApplications(
+    supabaseAdmin,
+    phaseId,
+  );
+  const { data: outcomes, error: outcomeError } = await supabaseAdmin
+    .from("phase_outcome_table")
+    .select("user_id,outcome")
+    .eq("phase_id", phaseId);
+  if (outcomeError) throw outcomeError;
+
+  const outcomesByApplicant = new Map<string, Set<boolean>>();
+  for (const outcome of outcomes ?? []) {
+    const values =
+      outcomesByApplicant.get(outcome.user_id) ?? new Set<boolean>();
+    values.add(outcome.outcome);
+    outcomesByApplicant.set(outcome.user_id, values);
+  }
+
+  const missingApplications = eligibleApplications.filter(
+    (application) => !outcomesByApplicant.has(application.applicantUserId),
+  );
+  if (missingApplications.length > 0) {
+    throw new Error(
+      `Für ${missingApplications.length} Startups fehlt noch eine Entscheidung.`,
+    );
+  }
+  const conflictingOutcomes = [...outcomesByApplicant.values()].filter(
+    (values) => values.size > 1,
+  );
+  if (conflictingOutcomes.length > 0) {
+    throw new Error(
+      "Es existieren widersprüchliche doppelte Entscheidungen. Bitte speichere die betroffenen Entscheidungen erneut.",
+    );
+  }
+
+  const finishedAt = new Date().toISOString();
+  const { error: finishError } = await supabaseAdmin
+    .from("phase_table")
+    .update({ finished_evaluation: finishedAt })
+    .eq("phaseid", phaseId)
+    .is("finished_evaluation", null);
+  if (finishError) throw finishError;
+
+  revalidatePath("/");
+  revalidatePath("/admin");
+  revalidatePath("/admin/evaluation");
+  return { finishedAt };
+}

--- a/frontend/src/actions/smtp.ts
+++ b/frontend/src/actions/smtp.ts
@@ -28,5 +28,6 @@ export async function sendEmail(to: string, subject: string, html: string) {
     });
   } catch (error) {
     log.error(JSON.stringify(error));
+    throw error;
   }
 }

--- a/frontend/src/app/admin/evaluation/page.tsx
+++ b/frontend/src/app/admin/evaluation/page.tsx
@@ -1,0 +1,20 @@
+import { fetchEvaluationDashboardData } from "@/actions/evaluation";
+import EvaluationWorkflow from "@/components/admin/evaluationWorkflow";
+import InternalHeader from "@/components/layout/internalHeader";
+import OverviewButton from "@/components/overviewButton";
+
+export default async function EvaluationPage() {
+  const data = await fetchEvaluationDashboardData();
+
+  return (
+    <div className="w-full">
+      <InternalHeader />
+      <OverviewButton slug="admin" text="<- Admin-Übersicht" />
+      <h1 className="mt-6 text-2xl font-bold">Bewertungsprozess</h1>
+      <p className="mt-2 text-sm text-gray-600">
+        Matching erstellen, Bewerter informieren und die Phase abschließen.
+      </p>
+      <EvaluationWorkflow data={data} />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,25 +1,22 @@
-import { fetchAllApplicantsStatus, fetchAllUsers } from "@/actions/admin";
-import { fetch_all_phases } from "@/actions/phase";
-import ApplicantsList from "@/components/applicantslist";
+import { fetchAllUsers } from "@/actions/admin";
 import InternalHeader from "@/components/layout/internalHeader";
 import UserList from "@/components/userslist";
+import Link from "next/link";
 
 export default async function Page() {
   const users = await fetchAllUsers();
-  const applicantsStatus = await fetchAllApplicantsStatus();
-  const phases = await fetch_all_phases();
   return (
     <div className="container mx-auto px-4 py-8">
       <InternalHeader />
       <h1 className="text-2xl font-bold mb-4">ADMIN DASHBOARD</h1>
+      <Link
+        href="/admin/evaluation"
+        className="apl-button-fixed inline-block mb-8"
+      >
+        Bewertungsprozess öffnen
+      </Link>
       <h2 className="text-xl font-bold mb-4">User List</h2>
       <UserList users={users} />
-      <h2 className="text-xl font-bold mb-4 mt-9">Applicants List</h2>
-      <ApplicantsList
-        users={users}
-        phases={phases.sort((a, b) => a.phaseorder - b.phaseorder)}
-        applicantsStatus={applicantsStatus}
-      />
     </div>
   );
 }

--- a/frontend/src/components/admin/evaluationWorkflow.tsx
+++ b/frontend/src/components/admin/evaluationWorkflow.tsx
@@ -1,0 +1,575 @@
+"use client";
+
+import { ChangeEvent, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  EvaluationDashboardData,
+  finishPhaseEvaluation,
+  previewReviewerMatching,
+  saveBulkPhaseDecisions,
+  savePhaseDecision,
+  saveReviewerAssignments,
+  sendReviewerAssignmentEmails,
+  sendReviewerTestEmail,
+} from "@/actions/evaluation";
+import { ReviewEmailDefaults } from "@/config/reviewEmailConfig";
+import { ReviewerAssignment } from "@/utils/reviewerMatching";
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "Unbekannter Fehler";
+}
+
+function decisionKey(phaseId: string, applicantUserId: string) {
+  return `${phaseId}:${applicantUserId}`;
+}
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase().replace("@googlemail.com", "@gmail.com");
+}
+
+const fieldClass =
+  "mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm text-secondary";
+
+export default function EvaluationWorkflow({
+  data,
+}: {
+  data: EvaluationDashboardData;
+}) {
+  const router = useRouter();
+  const defaultPhase =
+    data.phases.find((phase) => phase.finished_evaluation === null) ??
+    data.phases[0];
+  const [phaseId, setPhaseId] = useState(defaultPhase?.phaseid ?? "");
+  const [csvText, setCsvText] = useState("");
+  const [reviewersPerApplication, setReviewersPerApplication] = useState(2);
+  const [preview, setPreview] = useState<ReviewerAssignment[]>([]);
+  const [emailSettings, setEmailSettings] = useState<ReviewEmailDefaults>(
+    data.emailDefaults,
+  );
+  const [approvedEmails, setApprovedEmails] = useState("");
+  const [decisions, setDecisions] = useState<
+    Record<string, boolean | undefined>
+  >(
+    Object.fromEntries(
+      data.outcomes.map((outcome) => [
+        decisionKey(outcome.phaseId, outcome.applicantUserId),
+        outcome.outcome,
+      ]),
+    ),
+  );
+  const [pendingAction, setPendingAction] = useState("");
+  const [notice, setNotice] = useState("");
+  const [error, setError] = useState("");
+
+  const selectedPhase = data.phases.find((phase) => phase.phaseid === phaseId);
+  const currentAssignments = data.assignments.filter(
+    (assignment) => assignment.phaseId === phaseId,
+  );
+  const eligibleApplicantIds = new Set(
+    data.eligibleApplicantIdsByPhase[phaseId] ?? [],
+  );
+  const eligibleApplications = data.applications.filter((application) =>
+    eligibleApplicantIds.has(application.applicantUserId),
+  );
+
+  const currentAssignmentsByApplication = useMemo(() => {
+    const grouped = new Map<string, typeof currentAssignments>();
+    for (const assignment of currentAssignments) {
+      const assignments = grouped.get(assignment.applicationId) ?? [];
+      assignments.push(assignment);
+      grouped.set(assignment.applicationId, assignments);
+    }
+    return grouped;
+  }, [currentAssignments]);
+
+  async function runAction(name: string, action: () => Promise<string>) {
+    setPendingAction(name);
+    setNotice("");
+    setError("");
+    try {
+      setNotice(await action());
+    } catch (caughtError) {
+      setError(errorMessage(caughtError));
+    } finally {
+      setPendingAction("");
+    }
+  }
+
+  async function readCsv(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    setCsvText(file ? await file.text() : "");
+    setPreview([]);
+  }
+
+  function updateEmailSetting<Key extends keyof ReviewEmailDefaults>(
+    key: Key,
+    value: ReviewEmailDefaults[Key],
+  ) {
+    setEmailSettings((current) => ({ ...current, [key]: value }));
+  }
+
+  if (!selectedPhase) {
+    return <p className="mt-6">Es wurden keine Phasen gefunden.</p>;
+  }
+
+  return (
+    <div className="mt-8 space-y-8">
+      <label className="block font-semibold">
+        Phase
+        <select
+          className={fieldClass}
+          value={phaseId}
+          onChange={(event) => {
+            setPhaseId(event.target.value);
+            setPreview([]);
+            setNotice("");
+            setError("");
+          }}
+        >
+          {data.phases.map((phase) => (
+            <option key={phase.phaseid} value={phase.phaseid}>
+              {phase.phaseorder + 1}. {phase.phaselabel}
+              {phase.finished_evaluation ? " (abgeschlossen)" : ""}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {notice && (
+        <p className="rounded border border-green-300 bg-green-50 p-3 text-sm text-green-800">
+          {notice}
+        </p>
+      )}
+      {error && (
+        <p className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+          {error}
+        </p>
+      )}
+
+      <section className="rounded-lg border border-gray-200 p-5">
+        <h2 className="text-xl font-bold">1. Matching</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          {eligibleApplications.length} Startups sind für diese Phase
+          teilnahmeberechtigt. Die CSV benötigt die Spalten name, email, new und
+          max.
+        </p>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <label className="block text-sm font-medium">
+            Bewerter-CSV
+            <input
+              className={fieldClass}
+              type="file"
+              accept=".csv,text/csv"
+              onChange={readCsv}
+            />
+          </label>
+          <label className="block text-sm font-medium">
+            Bewerter pro Startup
+            <input
+              className={fieldClass}
+              type="number"
+              min={1}
+              max={10}
+              value={reviewersPerApplication}
+              onChange={(event) =>
+                setReviewersPerApplication(Number(event.target.value))
+              }
+            />
+          </label>
+        </div>
+        <button
+          type="button"
+          className="apl-button-fixed mt-4"
+          disabled={!csvText || pendingAction !== ""}
+          onClick={() =>
+            runAction("preview", async () => {
+              const result = await previewReviewerMatching(
+                phaseId,
+                csvText,
+                reviewersPerApplication,
+              );
+              setPreview(result);
+              return `${result.length} Zuweisungen wurden erfolgreich berechnet.`;
+            })
+          }
+        >
+          {pendingAction === "preview"
+            ? "Matching wird berechnet..."
+            : "Matching prüfen"}
+        </button>
+
+        {preview.length > 0 && (
+          <div className="mt-5 overflow-x-auto">
+            <h3 className="font-semibold">Vorschau</h3>
+            <table className="mt-2 min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-3 py-2 text-left">Startup</th>
+                  <th className="px-3 py-2 text-left">Bewerter</th>
+                  <th className="px-3 py-2 text-left">Erfahren</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {preview.map((assignment) => (
+                  <tr
+                    key={`${assignment.applicationId}-${assignment.reviewerUserId}`}
+                  >
+                    <td className="px-3 py-2">{assignment.teamName}</td>
+                    <td className="px-3 py-2">
+                      {assignment.reviewerName} ({assignment.reviewerEmail})
+                    </td>
+                    <td className="px-3 py-2">
+                      {assignment.reviewerIsExperienced ? "Ja" : "Nein"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <button
+              type="button"
+              className="apl-button-fixed mt-4"
+              disabled={pendingAction !== ""}
+              onClick={() => {
+                if (
+                  !window.confirm(
+                    "Das bisherige Matching dieser Phase wird vollständig ersetzt. Fortfahren?",
+                  )
+                ) {
+                  return;
+                }
+                runAction("save", async () => {
+                  const result = await saveReviewerAssignments(
+                    phaseId,
+                    preview,
+                  );
+                  setPreview([]);
+                  router.refresh();
+                  return `${result.savedAssignments} Zuweisungen wurden gespeichert.`;
+                });
+              }}
+            >
+              {pendingAction === "save"
+                ? "Matching wird gespeichert..."
+                : "Matching verbindlich speichern"}
+            </button>
+          </div>
+        )}
+
+        {currentAssignments.length > 0 && preview.length === 0 && (
+          <div className="mt-5">
+            <h3 className="font-semibold">
+              Gespeichertes Matching ({currentAssignments.length} Zuweisungen)
+            </h3>
+            <ul className="mt-2 space-y-1 text-sm">
+              {[...currentAssignmentsByApplication.values()].map(
+                (assignments) => (
+                  <li key={assignments[0].applicationId}>
+                    <strong>{assignments[0].teamName}:</strong>{" "}
+                    {assignments
+                      .map((assignment) => assignment.reviewerEmail)
+                      .join(", ")}
+                  </li>
+                ),
+              )}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-gray-200 p-5">
+        <h2 className="text-xl font-bold">2. E-Mail-Versand</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Die dauerhaften Standardwerte stehen in reviewEmailConfig.ts.
+          Änderungen hier gelten nur für diesen Versand.
+        </p>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <label className="block text-sm font-medium md:col-span-2">
+            Betreff
+            <input
+              className={fieldClass}
+              value={emailSettings.subject}
+              onChange={(event) =>
+                updateEmailSetting("subject", event.target.value)
+              }
+            />
+          </label>
+          <label className="block text-sm font-medium">
+            Bestätigungsfrist
+            <input
+              className={fieldClass}
+              value={emailSettings.confirmationDeadline}
+              onChange={(event) =>
+                updateEmailSetting("confirmationDeadline", event.target.value)
+              }
+            />
+          </label>
+          <label className="block text-sm font-medium">
+            Bestätigungsformular
+            <input
+              className={fieldClass}
+              type="url"
+              value={emailSettings.confirmationUrl}
+              onChange={(event) =>
+                updateEmailSetting("confirmationUrl", event.target.value)
+              }
+            />
+          </label>
+          <label className="block text-sm font-medium">
+            Bewertungsfrist
+            <input
+              className={fieldClass}
+              value={emailSettings.ratingDeadline}
+              onChange={(event) =>
+                updateEmailSetting("ratingDeadline", event.target.value)
+              }
+            />
+          </label>
+          <label className="block text-sm font-medium">
+            Anleitung
+            <input
+              className={fieldClass}
+              type="url"
+              value={emailSettings.instructionsUrl}
+              onChange={(event) =>
+                updateEmailSetting("instructionsUrl", event.target.value)
+              }
+            />
+          </label>
+          <label className="block text-sm font-medium">
+            Bewertungsformular
+            <input
+              className={fieldClass}
+              type="url"
+              value={emailSettings.ratingUrl}
+              onChange={(event) =>
+                updateEmailSetting("ratingUrl", event.target.value)
+              }
+            />
+          </label>
+          <label className="block text-sm font-medium md:col-span-2">
+            Hinweis für diese Phase
+            <textarea
+              className={fieldClass}
+              rows={4}
+              value={emailSettings.phaseNote}
+              onChange={(event) =>
+                updateEmailSetting("phaseNote", event.target.value)
+              }
+            />
+          </label>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <button
+            type="button"
+            className="apl-button-fixed"
+            disabled={currentAssignments.length === 0 || pendingAction !== ""}
+            onClick={() =>
+              runAction("test-email", async () => {
+                const result = await sendReviewerTestEmail(
+                  phaseId,
+                  emailSettings,
+                );
+                return `Testmail wurde an ${result.recipient} gesendet.`;
+              })
+            }
+          >
+            {pendingAction === "test-email"
+              ? "Wird gesendet..."
+              : "Testmail senden"}
+          </button>
+          <button
+            type="button"
+            className="apl-alert-button-fixed"
+            disabled={currentAssignments.length === 0 || pendingAction !== ""}
+            onClick={() => {
+              if (
+                !window.confirm(
+                  "Die Zuweisungen werden jetzt produktiv an alle Bewerter dieser Phase versendet. Fortfahren?",
+                )
+              ) {
+                return;
+              }
+              runAction("emails", async () => {
+                const result = await sendReviewerAssignmentEmails(
+                  phaseId,
+                  emailSettings,
+                );
+                return `${result.sentEmails} E-Mails wurden versendet.`;
+              });
+            }}
+          >
+            {pendingAction === "emails"
+              ? "E-Mails werden gesendet..."
+              : "Produktiv an alle senden"}
+          </button>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-gray-200 p-5">
+        <h2 className="text-xl font-bold">3. Entscheidungen und Abschluss</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Jede Entscheidung wird sofort gespeichert. Eine Phase kann erst
+          abgeschlossen werden, wenn alle Startups entschieden sind.
+        </p>
+        {selectedPhase.finished_evaluation === null && (
+          <div className="mt-4 rounded bg-gray-50 p-4">
+            <label className="block text-sm font-medium">
+              Liste der bestandenen E-Mail-Adressen
+              <textarea
+                className={fieldClass}
+                rows={4}
+                placeholder="team1@example.org&#10;team2@example.org"
+                value={approvedEmails}
+                onChange={(event) => setApprovedEmails(event.target.value)}
+              />
+            </label>
+            <p className="mt-2 text-xs text-gray-600">
+              Beim Anwenden werden alle aufgeführten Startups als bestanden und
+              alle übrigen teilnahmeberechtigten Startups als nicht bestanden
+              gespeichert.
+            </p>
+            <button
+              type="button"
+              className="apl-button-fixed mt-3"
+              disabled={pendingAction !== ""}
+              onClick={() => {
+                if (
+                  !window.confirm(
+                    `Die Liste setzt die Entscheidung für alle ${eligibleApplications.length} Startups. Fortfahren?`,
+                  )
+                ) {
+                  return;
+                }
+                runAction("bulk-decisions", async () => {
+                  const result = await saveBulkPhaseDecisions(
+                    phaseId,
+                    approvedEmails,
+                  );
+                  const approvedEmailSet = new Set(
+                    approvedEmails
+                      .split(/[\s,;]+/)
+                      .map(normalizeEmail)
+                      .filter(Boolean),
+                  );
+                  setDecisions((current) => ({
+                    ...current,
+                    ...Object.fromEntries(
+                      eligibleApplications.map((application) => [
+                        decisionKey(phaseId, application.applicantUserId),
+                        approvedEmailSet.has(normalizeEmail(application.email)),
+                      ]),
+                    ),
+                  }));
+                  router.refresh();
+                  return `${result.passed} bestanden, ${result.failed} nicht bestanden.`;
+                });
+              }}
+            >
+              {pendingAction === "bulk-decisions"
+                ? "Liste wird angewendet..."
+                : "Liste auf alle anwenden"}
+            </button>
+          </div>
+        )}
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2 text-left">Startup</th>
+                <th className="px-3 py-2 text-left">E-Mail</th>
+                <th className="px-3 py-2 text-left">Entscheidung</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {eligibleApplications.map((application) => (
+                <tr key={application.applicationId}>
+                  <td className="px-3 py-2">{application.teamName}</td>
+                  <td className="px-3 py-2">{application.email}</td>
+                  <td className="px-3 py-2">
+                    <select
+                      className="rounded border border-gray-300 px-2 py-1"
+                      disabled={
+                        selectedPhase.finished_evaluation !== null ||
+                        pendingAction !== ""
+                      }
+                      value={
+                        decisions[
+                          decisionKey(phaseId, application.applicantUserId)
+                        ] === undefined
+                          ? ""
+                          : decisions[
+                                decisionKey(
+                                  phaseId,
+                                  application.applicantUserId,
+                                )
+                              ]
+                            ? "passed"
+                            : "failed"
+                      }
+                      onChange={(event) => {
+                        if (!event.target.value) return;
+                        const outcome = event.target.value === "passed";
+                        runAction(
+                          `decision-${application.applicantUserId}`,
+                          async () => {
+                            await savePhaseDecision(
+                              phaseId,
+                              application.applicantUserId,
+                              outcome,
+                            );
+                            setDecisions((current) => ({
+                              ...current,
+                              [decisionKey(
+                                phaseId,
+                                application.applicantUserId,
+                              )]: outcome,
+                            }));
+                            return `Entscheidung für ${application.teamName} wurde gespeichert.`;
+                          },
+                        );
+                      }}
+                    >
+                      <option value="">Offen</option>
+                      <option value="passed">Bestanden</option>
+                      <option value="failed">Nicht bestanden</option>
+                    </select>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {selectedPhase.finished_evaluation ? (
+          <p className="mt-4 font-semibold text-green-700">
+            Phase abgeschlossen am {selectedPhase.finished_evaluation}
+          </p>
+        ) : (
+          <button
+            type="button"
+            className="apl-alert-button-fixed mt-4"
+            disabled={pendingAction !== "" || eligibleApplications.length === 0}
+            onClick={() => {
+              if (
+                !window.confirm(
+                  "Nach dem Abschluss werden die Ergebnisse für Bewerber sichtbar. Phase wirklich abschließen?",
+                )
+              ) {
+                return;
+              }
+              runAction("finish", async () => {
+                await finishPhaseEvaluation(phaseId);
+                router.refresh();
+                return "Die Phase wurde abgeschlossen.";
+              });
+            }}
+          >
+            {pendingAction === "finish"
+              ? "Phase wird abgeschlossen..."
+              : "Phase verbindlich abschließen"}
+          </button>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/questiontypes/imageupload_questiontype.tsx
+++ b/frontend/src/components/questiontypes/imageupload_questiontype.tsx
@@ -7,8 +7,12 @@ import Image from "next/image";
 import { createLogger } from "@/logger/logger";
 import { UpdateAnswer } from "@/store/slices/answerSlice";
 import { useAppDispatch, useAppSelector } from "@/store/store";
-import { downloadFile, storageSaveName } from "@/utils/helpers";
-import { saveUploadAnswer, fetchUploadAnswer } from "@/utils/uploadHelpers";
+import { storageSaveName } from "@/utils/helpers";
+import {
+  downloadApplicationFile,
+  fetchUploadAnswer,
+  saveUploadAnswer,
+} from "@/utils/uploadHelpers";
 
 import QuestionTypes, { DefaultQuestionTypeProps } from "./questiontypes";
 import { AwaitingChild } from "../layout/awaiting";
@@ -107,12 +111,12 @@ const ImageUploadQuestionType: React.FC<ImageUploadQuestionTypeProps> = ({
           applicationid,
         );
         if (savedAnswer && savedAnswer.imagename != "") {
-          const imageUploadBucketData = await downloadFile(
-            `image-${questionid}`,
-            `${savedAnswer!.userid}_${savedAnswer!.imagename}`,
+          const file = await downloadApplicationFile(
+            applicationid,
+            questionid,
+            "image",
           );
-          log.debug(imageUploadBucketData);
-          const url = URL.createObjectURL(imageUploadBucketData!);
+          const url = URL.createObjectURL(file);
           updateAnswerState(url || "");
           setWasUploaded(true);
         } else {

--- a/frontend/src/components/questiontypes/pdfupload_questiontype.tsx
+++ b/frontend/src/components/questiontypes/pdfupload_questiontype.tsx
@@ -5,13 +5,17 @@ import React, { useCallback, useEffect, useState } from "react";
 import { createLogger } from "@/logger/logger";
 import { UpdateAnswer } from "@/store/slices/answerSlice";
 import { useAppDispatch, useAppSelector } from "@/store/store";
-import { downloadFile, storageSaveName } from "@/utils/helpers";
+import { storageSaveName } from "@/utils/helpers";
 
 import QuestionTypes, { DefaultQuestionTypeProps } from "./questiontypes";
 import { AwaitingChild } from "../layout/awaiting";
 import { SubmitButton } from "../submitButton";
 import { deletePdfUploadAnswer } from "@/actions/answers/deleteUpload";
-import { fetchUploadAnswer, saveUploadAnswer } from "@/utils/uploadHelpers";
+import {
+  downloadApplicationFile,
+  fetchUploadAnswer,
+  saveUploadAnswer,
+} from "@/utils/uploadHelpers";
 
 const log = createLogger("components/questiontypes/pdfupload_questiontype");
 
@@ -106,11 +110,12 @@ const PDFUploadQuestionType: React.FC<PDFUploadQuestionTypeProps> = ({
           applicationid,
         );
         if (savedAnswer && savedAnswer?.pdfname != "") {
-          const imageUploadBucketData = await downloadFile(
-            `pdf-${questionid}`,
-            `${savedAnswer!.userid}_${savedAnswer!.pdfname}`,
+          const file = await downloadApplicationFile(
+            applicationid,
+            questionid,
+            "pdf",
           );
-          const url = URL.createObjectURL(imageUploadBucketData!);
+          const url = URL.createObjectURL(file);
           updateAnswerState(url || "");
           setWasUploaded(true);
         } else {

--- a/frontend/src/components/questiontypes/videoupload_questiontype.tsx
+++ b/frontend/src/components/questiontypes/videoupload_questiontype.tsx
@@ -5,12 +5,16 @@ import React, { useCallback, useEffect, useState } from "react";
 import { createLogger } from "@/logger/logger";
 import { UpdateAnswer } from "@/store/slices/answerSlice";
 import { useAppDispatch, useAppSelector } from "@/store/store";
-import { downloadFile, storageSaveName } from "@/utils/helpers";
+import { storageSaveName } from "@/utils/helpers";
 
 import QuestionTypes, { DefaultQuestionTypeProps } from "./questiontypes";
 import { AwaitingChild } from "../layout/awaiting";
 import { SubmitButton } from "../submitButton";
-import { fetchUploadAnswer, saveUploadAnswer } from "@/utils/uploadHelpers";
+import {
+  downloadApplicationFile,
+  fetchUploadAnswer,
+  saveUploadAnswer,
+} from "@/utils/uploadHelpers";
 import { deleteVideoUploadAnswer } from "@/actions/answers/deleteUpload";
 
 const log = createLogger("components/questiontypes/videoupload_questiontype");
@@ -105,11 +109,12 @@ const VideoUploadQuestionType: React.FC<VideoUploadQuestionTypeProps> = ({
           applicationid,
         );
         if (savedAnswer && savedAnswer?.videoname != "") {
-          const VideoUploadBucketData = await downloadFile(
-            `video-${questionid}`,
-            `${savedAnswer!.userid}_${savedAnswer!.videoname}`,
+          const file = await downloadApplicationFile(
+            applicationid,
+            questionid,
+            "video",
           );
-          const url = URL.createObjectURL(VideoUploadBucketData!);
+          const url = URL.createObjectURL(file);
           updateAnswerState(url || "");
           setWasUploaded(true);
         } else {

--- a/frontend/src/config/reviewEmailConfig.ts
+++ b/frontend/src/config/reviewEmailConfig.ts
@@ -1,0 +1,26 @@
+export interface ReviewEmailDefaults {
+  subject: string;
+  confirmationDeadline: string;
+  confirmationUrl: string;
+  ratingDeadline: string;
+  instructionsUrl: string;
+  ratingUrl: string;
+  phaseNote: string;
+}
+
+/**
+ * Adjust these defaults once per competition year. Admins can still change
+ * them for a single send on the preview page.
+ */
+export const reviewEmailDefaults: ReviewEmailDefaults = {
+  subject: "[Generation-D] Bewertungsrunde",
+  confirmationDeadline: "26.03.2026, 23:59 Uhr",
+  confirmationUrl:
+    "https://airtable.com/applJfvdubKSjA6sh/pagcmQICeaUnWo2Nc/form",
+  ratingDeadline: "07.04.2026, 23:59 Uhr",
+  instructionsUrl:
+    "https://drive.google.com/file/d/1INO07NK5r__TzvVUJQayzfF8UKI-Sbq8/view?usp=sharing",
+  ratingUrl: "https://airtable.com/applJfvdubKSjA6sh/pagLOnHMhpF53Df27/form",
+  phaseNote:
+    "Wenn Du Mitglieder eines Teams bereits kennst, melde Dich bitte baldmöglichst bei uns, damit wir das Team neu zuweisen können.",
+};

--- a/frontend/src/emails/reviewerAssignmentEmail.ts
+++ b/frontend/src/emails/reviewerAssignmentEmail.ts
@@ -1,0 +1,64 @@
+export interface ReviewerEmailApplication {
+  teamName: string;
+}
+
+export interface ReviewerAssignmentEmailData {
+  phaseLabel: string;
+  confirmationDeadline: string;
+  confirmationUrl: string;
+  ratingDeadline: string;
+  instructionsUrl: string;
+  ratingUrl: string;
+  reviewUrl: string;
+  phaseNote: string;
+  applications: ReviewerEmailApplication[];
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function safeHttpUrl(value: string) {
+  const url = new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Nicht unterstützter Link: ${value}`);
+  }
+  return escapeHtml(url.toString());
+}
+
+export function createReviewerAssignmentEmail({
+  phaseLabel,
+  confirmationDeadline,
+  confirmationUrl,
+  ratingDeadline,
+  instructionsUrl,
+  ratingUrl,
+  reviewUrl,
+  phaseNote,
+  applications,
+}: ReviewerAssignmentEmailData) {
+  const applicationItems = applications
+    .sort((left, right) => left.teamName.localeCompare(right.teamName))
+    .map((application) => `<li>${escapeHtml(application.teamName)}</li>`)
+    .join("");
+
+  return `
+    <p>Hallo,</p>
+    <p>danke, dass Du Generation-D bei der Bewertungsrunde <strong>${escapeHtml(phaseLabel)}</strong> unterstützt!</p>
+    <p>Bitte bestätige den Erhalt dieser Nachricht bis <strong>${escapeHtml(confirmationDeadline)}</strong>:<br><a href="${safeHttpUrl(confirmationUrl)}">Empfang bestätigen</a></p>
+    <p><strong>Anleitung:</strong><br><a href="${safeHttpUrl(instructionsUrl)}">${safeHttpUrl(instructionsUrl)}</a></p>
+    <p><strong>Bewertungsformular:</strong><br><a href="${safeHttpUrl(ratingUrl)}">${safeHttpUrl(ratingUrl)}</a></p>
+    <p><strong>Deine Bewerbungen im Portal:</strong><br><a href="${safeHttpUrl(reviewUrl)}">${safeHttpUrl(reviewUrl)}</a></p>
+    <p>Bitte schließe Deine Bewertungen bis <strong>${escapeHtml(ratingDeadline)}</strong> ab.</p>
+    <p><strong>Deine zu bewertenden Teams:</strong></p>
+    <ul>${applicationItems}</ul>
+    <p><strong>Hinweis für diese Phase:</strong><br>${escapeHtml(phaseNote)}</p>
+    <p>Falls Du Fragen hast oder Probleme auftreten, melde Dich gerne jederzeit bei uns.</p>
+    <p>Viele Grüße<br>Euer Generation-D Team</p>
+  `;
+}

--- a/frontend/src/supabase-utils/cookiesUtilClient.ts
+++ b/frontend/src/supabase-utils/cookiesUtilClient.ts
@@ -1,5 +1,6 @@
 import { Database } from "@/types/database.types";
 import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 
 export const getSupabaseCookiesUtilClient = async () => {
@@ -47,3 +48,16 @@ export const getSupabaseCookiesUtilClientAdmin = async () => {
     },
   );
 };
+
+/** Service-role client for server actions after they explicitly checked admin access. */
+export const getSupabaseServiceRoleClient = () =>
+  createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -1,4 +1,3 @@
-import { getSupabaseBrowserClient } from "@/supabase-utils/browserClient";
 import { TZDate } from "@date-fns/tz";
 import { format } from "date-fns";
 
@@ -37,18 +36,6 @@ export function transformReadableDateTime(dateString: string) {
   if (!dateString) return "";
   const zonedDate = new TZDate(new Date(dateString), TIMEZONE);
   return format(zonedDate, "dd.MM.yyyy HH:mm");
-}
-
-export async function downloadFile(bucket_name: string, filename: string) {
-  const supabase = getSupabaseBrowserClient();
-
-  const { data: fileUploadBucketData, error: fileUploadBucketError } =
-    await supabase.storage.from(bucket_name).download(filename);
-  if (fileUploadBucketError) {
-    return;
-  }
-  // Can't return Blob from Server Component to Client Component!
-  return fileUploadBucketData!;
 }
 
 export function calcPhaseStatus(phaseStart: string, phaseEnd: string) {

--- a/frontend/src/utils/reviewerMatching.ts
+++ b/frontend/src/utils/reviewerMatching.ts
@@ -1,0 +1,179 @@
+export interface MatchingApplication {
+  applicationId: string;
+  applicantUserId: string;
+  teamName: string;
+  email: string;
+}
+
+export interface MatchingReviewer {
+  userId: string;
+  name: string;
+  email: string;
+  isExperienced: boolean;
+  maxApplications: number;
+}
+
+export interface ReviewerAssignment {
+  applicationId: string;
+  applicantUserId: string;
+  teamName: string;
+  applicantEmail: string;
+  reviewerUserId: string;
+  reviewerName: string;
+  reviewerEmail: string;
+  reviewerIsExperienced: boolean;
+}
+
+function byCurrentLoadThenEmail(assignmentsByReviewer: Map<string, string[]>) {
+  return (left: MatchingReviewer, right: MatchingReviewer) => {
+    const loadDifference =
+      assignmentsByReviewer.get(left.userId)!.length -
+      assignmentsByReviewer.get(right.userId)!.length;
+
+    return loadDifference || left.email.localeCompare(right.email);
+  };
+}
+
+/**
+ * Deterministic version of the matching used by the former Python process.
+ * Each application receives one experienced reviewer first. Remaining places
+ * are filled with the currently least-loaded eligible reviewer.
+ */
+export function assignReviewers(
+  applications: MatchingApplication[],
+  reviewers: MatchingReviewer[],
+  reviewersPerApplication: number,
+): ReviewerAssignment[] {
+  if (
+    !Number.isInteger(reviewersPerApplication) ||
+    reviewersPerApplication < 1
+  ) {
+    throw new Error(
+      "Die Anzahl der Bewerter pro Startup muss mindestens 1 sein.",
+    );
+  }
+  if (applications.length === 0) {
+    throw new Error(
+      "Für diese Phase wurden keine teilnahmeberechtigten Startups gefunden.",
+    );
+  }
+  if (reviewers.length < reviewersPerApplication) {
+    throw new Error(
+      "Es stehen nicht genügend unterschiedliche Bewerter zur Verfügung.",
+    );
+  }
+
+  const reviewerIds = new Set<string>();
+  for (const reviewer of reviewers) {
+    if (reviewerIds.has(reviewer.userId)) {
+      throw new Error(`Bewerter ${reviewer.email} kommt mehrfach vor.`);
+    }
+    if (
+      !Number.isInteger(reviewer.maxApplications) ||
+      reviewer.maxApplications < 0
+    ) {
+      throw new Error(`Die Kapazität von ${reviewer.email} ist ungültig.`);
+    }
+    reviewerIds.add(reviewer.userId);
+  }
+
+  const requiredAssignments = applications.length * reviewersPerApplication;
+  const totalCapacity = reviewers.reduce(
+    (sum, reviewer) => sum + reviewer.maxApplications,
+    0,
+  );
+  if (totalCapacity < requiredAssignments) {
+    throw new Error(
+      `Es werden ${requiredAssignments} Zuweisungen benötigt, aber die Gesamtkapazität beträgt nur ${totalCapacity}.`,
+    );
+  }
+
+  const experiencedCapacity = reviewers
+    .filter((reviewer) => reviewer.isExperienced)
+    .reduce((sum, reviewer) => sum + reviewer.maxApplications, 0);
+  if (experiencedCapacity < applications.length) {
+    throw new Error(
+      `Für ${applications.length} Startups werden erfahrene Bewerter benötigt, deren Kapazität beträgt aber nur ${experiencedCapacity}.`,
+    );
+  }
+
+  const sortedApplications = [...applications].sort((left, right) =>
+    left.applicationId.localeCompare(right.applicationId),
+  );
+  const assignmentsByReviewer = new Map(
+    reviewers.map((reviewer) => [reviewer.userId, [] as string[]]),
+  );
+  const reviewersByApplication = new Map(
+    sortedApplications.map((application) => [
+      application.applicationId,
+      [] as MatchingReviewer[],
+    ]),
+  );
+
+  for (const application of sortedApplications) {
+    const experiencedReviewer = reviewers
+      .filter(
+        (reviewer) =>
+          reviewer.isExperienced &&
+          assignmentsByReviewer.get(reviewer.userId)!.length <
+            reviewer.maxApplications,
+      )
+      .sort(byCurrentLoadThenEmail(assignmentsByReviewer))[0];
+
+    if (!experiencedReviewer) {
+      throw new Error(
+        `Für ${application.teamName} konnte kein erfahrener Bewerter gefunden werden.`,
+      );
+    }
+
+    reviewersByApplication
+      .get(application.applicationId)!
+      .push(experiencedReviewer);
+    assignmentsByReviewer
+      .get(experiencedReviewer.userId)!
+      .push(application.applicationId);
+  }
+
+  for (const application of sortedApplications) {
+    const assignedReviewers = reviewersByApplication.get(
+      application.applicationId,
+    )!;
+
+    while (assignedReviewers.length < reviewersPerApplication) {
+      const nextReviewer = reviewers
+        .filter(
+          (reviewer) =>
+            !assignedReviewers.some(
+              (assignedReviewer) => assignedReviewer.userId === reviewer.userId,
+            ) &&
+            assignmentsByReviewer.get(reviewer.userId)!.length <
+              reviewer.maxApplications,
+        )
+        .sort(byCurrentLoadThenEmail(assignmentsByReviewer))[0];
+
+      if (!nextReviewer) {
+        throw new Error(
+          `Für ${application.teamName} konnten nicht genügend Bewerter gefunden werden.`,
+        );
+      }
+
+      assignedReviewers.push(nextReviewer);
+      assignmentsByReviewer
+        .get(nextReviewer.userId)!
+        .push(application.applicationId);
+    }
+  }
+
+  return sortedApplications.flatMap((application) =>
+    reviewersByApplication.get(application.applicationId)!.map((reviewer) => ({
+      applicationId: application.applicationId,
+      applicantUserId: application.applicantUserId,
+      teamName: application.teamName,
+      applicantEmail: application.email,
+      reviewerUserId: reviewer.userId,
+      reviewerName: reviewer.name,
+      reviewerEmail: reviewer.email,
+      reviewerIsExperienced: reviewer.isExperienced,
+    })),
+  );
+}

--- a/frontend/src/utils/uploadHelpers.ts
+++ b/frontend/src/utils/uploadHelpers.ts
@@ -1,5 +1,6 @@
 import { getSupabaseBrowserClient } from "@/supabase-utils/browserClient";
 import { saveAnswerClient } from "@/actions/answers/answers";
+import { getApplicationUploadUrl } from "@/actions/answers/downloadUpload";
 import { createLogger } from "@/logger/logger";
 
 const log = createLogger("utils/uploadHelpers");
@@ -13,6 +14,23 @@ export type UploadRpcName =
   | "fetch_image_upload_answer_table"
   | "fetch_pdf_upload_answer_table"
   | "fetch_video_upload_answer_table";
+
+export async function downloadApplicationFile(
+  applicationId: string,
+  questionId: string,
+  uploadType: "image" | "pdf" | "video",
+) {
+  const signedUrl = await getApplicationUploadUrl(
+    applicationId,
+    questionId,
+    uploadType,
+  );
+  const response = await fetch(signedUrl);
+  if (!response.ok) {
+    throw new Error("Die hochgeladene Datei konnte nicht geladen werden.");
+  }
+  return response.blob();
+}
 
 export async function saveUploadAnswer(
   questionid: string,

--- a/supabase/migrations/20260819190000_limit_reviewers_to_assignments.sql
+++ b/supabase/migrations/20260819190000_limit_reviewers_to_assignments.sql
@@ -1,0 +1,213 @@
+-- Reviewers may only access applications assigned to them. This migration
+-- intentionally reuses the existing tables and does not add schema fields.
+
+drop policy if exists "select_reviewer_application_table" on public.application_table;
+drop policy if exists "select_reviewer_answer_table" on public.answer_table;
+drop policy if exists "select_reviewer_checkbox_answer_table" on public.checkbox_answer_table;
+drop policy if exists "select_reviewer_conditional_answer_table" on public.conditional_answer_table;
+drop policy if exists "select_reviewer_date_picker_answer_table" on public.date_picker_answer_table;
+drop policy if exists "select_reviewer_datetime_picker_answer_table" on public.datetime_picker_answer_table;
+drop policy if exists "select_reviewer_dropdown_answer_table" on public.dropdown_answer_table;
+drop policy if exists "select_reviewer_image_upload_answer_table" on public.image_upload_answer_table;
+drop policy if exists "select_reviewer_long_text_answer_table" on public.long_text_answer_table;
+drop policy if exists "select_reviewer_multiple_choice_answer_table" on public.multiple_choice_answer_table;
+drop policy if exists "select_reviewer_number_picker_answer_table" on public.number_picker_answer_table;
+drop policy if exists "select_reviewer_pdf_upload_answer_table" on public.pdf_upload_answer_table;
+drop policy if exists "select_reviewer_short_text_answer_table" on public.short_text_answer_table;
+drop policy if exists "select_reviewer_video_upload_answer_table" on public.video_upload_answer_table;
+
+drop policy if exists "select_answer_for_viewer" on public.answer_table;
+drop policy if exists "select_checkbox_answer_for_viewer" on public.checkbox_answer_table;
+drop policy if exists "select_conditional_answer_for_viewer" on public.conditional_answer_table;
+drop policy if exists "select_date_picker_answer_for_viewer" on public.date_picker_answer_table;
+drop policy if exists "select_datetime_picker_answer_for_viewer" on public.datetime_picker_answer_table;
+drop policy if exists "select_dropdown_answer_for_viewer" on public.dropdown_answer_table;
+drop policy if exists "select_image_upload_answer_for_viewer" on public.image_upload_answer_table;
+drop policy if exists "select_long_text_answer_for_viewer" on public.long_text_answer_table;
+drop policy if exists "select_multiple_choice_answer_for_viewer" on public.multiple_choice_answer_table;
+drop policy if exists "select_number_picker_answer_for_viewer" on public.number_picker_answer_table;
+drop policy if exists "select_pdf_upload_answer_for_viewer" on public.pdf_upload_answer_table;
+drop policy if exists "select_short_text_answer_for_viewer" on public.short_text_answer_table;
+drop policy if exists "select_video_upload_answer_for_viewer" on public.video_upload_answer_table;
+
+create policy "select_own_reviewer_assignments"
+on public.phase_assignment_table
+as permissive
+for select
+to authenticated
+using (
+  user_role_2_id = auth.uid()
+  or exists (
+    select 1
+    from public.user_profiles_table
+    where userid = auth.uid() and userrole = 3
+  )
+);
+
+create policy "select_assigned_application_for_reviewer"
+on public.application_table
+as permissive
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.phase_assignment_table assignment
+    where assignment.user_role_1_id = application_table.userid
+      and assignment.user_role_2_id = auth.uid()
+  )
+);
+
+-- An assignment for a later phase includes the material from earlier phases,
+-- matching the previous PDF-based process.
+create policy "select_assigned_answer_for_reviewer"
+on public.answer_table
+as permissive
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.application_table application
+    join public.question_table question
+      on question.questionid = answer_table.questionid
+    join public.phase_table answer_phase
+      on answer_phase.phaseid = question.phaseid
+    join public.phase_assignment_table assignment
+      on assignment.user_role_1_id = application.userid
+      and assignment.user_role_2_id = auth.uid()
+    join public.phase_table assignment_phase
+      on assignment_phase.phaseid = assignment.phase_id
+    where application.applicationid = answer_table.applicationid
+      and answer_phase.phaseorder <= assignment_phase.phaseorder
+  )
+);
+
+create policy "select_accessible_checkbox_answer"
+on public.checkbox_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = checkbox_answer_table.answerid));
+
+create policy "select_accessible_conditional_answer"
+on public.conditional_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = conditional_answer_table.answerid));
+
+create policy "select_accessible_date_picker_answer"
+on public.date_picker_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = date_picker_answer_table.answerid));
+
+create policy "select_accessible_datetime_picker_answer"
+on public.datetime_picker_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = datetime_picker_answer_table.answerid));
+
+create policy "select_accessible_dropdown_answer"
+on public.dropdown_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = dropdown_answer_table.answerid));
+
+create policy "select_accessible_image_upload_answer"
+on public.image_upload_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = image_upload_answer_table.answerid));
+
+create policy "select_accessible_long_text_answer"
+on public.long_text_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = long_text_answer_table.answerid));
+
+create policy "select_accessible_multiple_choice_answer"
+on public.multiple_choice_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = multiple_choice_answer_table.answerid));
+
+create policy "select_accessible_number_picker_answer"
+on public.number_picker_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = number_picker_answer_table.answerid));
+
+create policy "select_accessible_pdf_upload_answer"
+on public.pdf_upload_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = pdf_upload_answer_table.answerid));
+
+create policy "select_accessible_short_text_answer"
+on public.short_text_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = short_text_answer_table.answerid));
+
+create policy "select_accessible_video_upload_answer"
+on public.video_upload_answer_table for select to authenticated
+using (exists (select 1 from public.answer_table answer where answer.answerid = video_upload_answer_table.answerid));
+
+-- The old policy exposed every outcome to every signed-in user.
+drop policy if exists "select_policy" on public.phase_outcome_table;
+
+create policy "select_relevant_phase_outcomes"
+on public.phase_outcome_table
+as permissive
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.user_profiles_table
+    where userid = auth.uid() and userrole = 3
+  )
+  or exists (
+    select 1
+    from public.phase_assignment_table assignment
+    where assignment.user_role_1_id = phase_outcome_table.user_id
+      and assignment.user_role_2_id = auth.uid()
+  )
+  or (
+    user_id = auth.uid()
+    and exists (
+      select 1
+      from public.phase_table phase
+      where phase.phaseid = phase_outcome_table.phase_id
+        and phase.finished_evaluation is not null
+    )
+  )
+);
+
+-- Reviewers download uploads through a checked server action and a short-lived
+-- signed URL instead of receiving blanket access to every storage object.
+drop policy if exists "all_cmds_for_atleast_viewer" on storage.buckets;
+drop policy if exists "all_cmds_for_atleast_viewer" on storage.objects;
+
+create or replace function public.fetch_applications_paginated(
+  page_size int default 10,
+  page_number int default 1
+)
+returns table (
+  applicationid uuid,
+  team_name text,
+  email varchar(255)
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  offset_val int := (page_number - 1) * page_size;
+  current_role int;
+begin
+  select userrole into current_role
+  from public.user_profiles_table
+  where userid = auth.uid() and isactive = true;
+
+  if current_role is null or current_role < 2 then
+    raise exception 'Access Denied';
+  end if;
+
+  return query
+  select
+    application.applicationid,
+    application.team_name,
+    users.email
+  from public.users users
+  join public.application_table application on users.id = application.userid
+  where current_role = 3
+    or exists (
+      select 1
+      from public.phase_assignment_table assignment
+      where assignment.user_role_1_id = application.userid
+        and assignment.user_role_2_id = auth.uid()
+    )
+  order by application.applicationid
+  limit page_size
+  offset offset_val;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add a phase-based admin workflow for reviewer matching, assignment emails, and outcomes
- reuse the existing phase assignment/outcome tables without adding tables or columns
- restrict reviewer access to assigned applications and provide checked upload downloads
- add fixed, versioned annual email defaults and tests

## Why
Replaces steps 3-5 of the former manual Bewertungsprozess in the application portal while keeping the implementation maintainable without AI.

## Automated validation
- `npm run test:scripts` — 8 tests passing
- `npm run lint` — passing
- `npx tsc --noEmit` — passing
- `npm run build` — passing
- GitHub Actions — 6/6 checks passing (build, lint, dependency review, and SonarCloud)

## Live end-to-end proof
Verified in the real Next.js UI against a fresh, isolated local Supabase instance with all migrations and seed data applied:

1. Direct access to `/admin/evaluation` without a session redirected to `/login`.
2. The seeded admin authenticated and opened the new workflow from the admin dashboard.
3. A demo phase with 5 eligible startups loaded successfully.
4. A reviewer CSV with one experienced and one new reviewer was uploaded.
5. The matching preview deterministically calculated 10 assignments (5 startups × 2 reviewers), with one experienced reviewer per startup.
6. The matching was confirmed and persisted; refreshing showed `Gespeichertes Matching (10 Zuweisungen)`.
7. The fixed annual email defaults rendered in the portal, and the email actions became enabled after assignments existed.
8. Applying the approved-email list persisted `2 bestanden, 3 nicht bestanden`.
9. Finishing the phase persisted the completion timestamp, marked the phase as completed, and disabled all decision controls.
10. Server logs confirmed successful calls to `previewReviewerMatching`, `saveReviewerAssignments`, `saveBulkPhaseDecisions`, and `finishPhaseEvaluation`.

The isolated demo containers, volumes, and test data were removed afterwards. The unrelated `Gems_App` Supabase instance remained untouched.

## Notes
- No productive SMTP email was sent. Email HTML generation is covered by automated tests; the live proof verified the configured template fields and that send actions are enabled after matching.
- This PR targets `python-removal` because the implementation builds on that branch.